### PR TITLE
Bump `sentinel-dashboard.jar` from 1.6.0 to 1.6.1

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -14,7 +14,7 @@ on:
       - published
 
 env:
-  SENTINEL_DASHBOARD_VERSION: 1.6.0
+  SENTINEL_DASHBOARD_VERSION: 1.6.1
   RUN_JAVA_SH_VERSION: v1.3.8
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.1] - 2020-08-12
+### Changed
+- Bump `sentinel-dashboard.jar` from 1.6.0 to [1.6.1](https://github.com/alibaba/Sentinel/releases/download/1.6.1/sentinel-dashboard-1.6.1.jar).
+
 ## [1.6.0] - 2020-08-12
 ### Added
 - Set the base image to `adoptopenjdk/openjdk8:jre8u262-b10-alpine`.


### PR DESCRIPTION
Bump `sentinel-dashboard.jar` from 1.6.0 to 1.6.1